### PR TITLE
feat: create introduction section

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,7 @@
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
+  images: { domains: ['media.discordapp.net'] },
 }
 
 module.exports = nextConfig

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,10 +3,10 @@ import Header from '~/src/components/Header'
 
 const Home = () => {
   return (
-    <>
+    <main>
       <Header />
       <Introduction />
-    </>
+    </main>
   )
 }
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,7 @@
+import Introduction from '~/src/components/Introduction'
+
 const Home = () => {
-  return <h1 className='text-3xl font-bold underline'>HELLO WORLD!</h1>
+  return <Introduction />
 }
 
 export default Home

--- a/src/components/Button/Button.data.ts
+++ b/src/components/Button/Button.data.ts
@@ -1,0 +1,11 @@
+const STYLES = {
+  filled: 'filled',
+  outlined: 'outlined',
+}
+
+export const conditionsStyle = (style: string) => {
+  return {
+    isFilled: style === STYLES.filled,
+    isOutlined: style === STYLES.outlined,
+  }
+}

--- a/src/components/Button/Button.spec.tsx
+++ b/src/components/Button/Button.spec.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react'
+
+import Button from '.'
+
+describe('<Button />', () => {
+  const setup = props => {
+    render(<Button {...props} />)
+  }
+
+  const getButton = () => {
+    return screen.getByRole('button', { name: /default/i })
+  }
+
+  const defaultProps = {
+    content: 'default',
+    padding: 'px-11',
+    style: 'filled',
+    textColor: 'text-blue-500',
+    bgColor: 'bg-blue-500',
+  }
+
+  it('should render content correctly', () => {
+    const content = 'One night with you'
+
+    setup({
+      ...defaultProps,
+      content,
+    })
+
+    expect(screen.getByText(content)).toBeInTheDocument()
+  })
+
+  it('should change textColro prop correctly', () => {
+    setup(defaultProps)
+
+    const button = getButton()
+
+    expect(button).toHaveClass('text-blue-500')
+  })
+
+  it('should change bgColor prop correctly', () => {
+    setup({ ...defaultProps, bgColor: 'bg-black' })
+
+    const button = getButton()
+
+    expect(button).toHaveClass('bg-black')
+  })
+
+  it('should change padding prop correctly', () => {
+    setup({ ...defaultProps, padding: 'px-10' })
+
+    const button = getButton()
+
+    expect(button).toHaveClass('px-10')
+  })
+
+  it('should render outlined style correctly', () => {
+    setup({ ...defaultProps, style: 'outlined' })
+
+    const button = getButton()
+
+    expect(button).toHaveClass('outline outline-2')
+  })
+})

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,12 +1,34 @@
+import { conditionsStyle } from './Button.data'
+
 type ButtonProps = {
   content: string
-  color: string
+  style: 'filled' | 'outlined'
+  bgColor?: 'bg-blue-500'
+  textColor: 'text-white' | 'text-blue-500'
+  padding: 'px-9' | 'px-11'
 }
 
-const Button = ({ content, color }: ButtonProps) => {
+const Button = ({
+  content,
+  style,
+  bgColor,
+  textColor,
+  padding,
+}: ButtonProps) => {
+  const { isFilled, isOutlined } = conditionsStyle(style)
+
   return (
     <button
-      className={`rounded-3xl py-3 px-9 text-white text-lg font-semibold ${color}`}
+      className={`
+        rounded-3xl
+        py-3
+        text-lg
+        font-semibold
+        ${textColor} 
+        ${padding} 
+        ${isOutlined && 'outline outline-2'} 
+        ${isFilled && bgColor}
+      `}
     >
       {content}
     </button>

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,0 +1,16 @@
+type ButtonProps = {
+  content: string
+  color: string
+}
+
+const Button = ({ content, color }: ButtonProps) => {
+  return (
+    <button
+      className={`rounded-3xl py-3 px-9 text-white text-lg font-semibold ${color}`}
+    >
+      {content}
+    </button>
+  )
+}
+
+export default Button

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -24,6 +24,9 @@ const Button = ({
         py-3
         text-lg
         font-semibold
+        hover:opacity-75
+        delay-50 
+        duration-500
         ${textColor} 
         ${padding} 
         ${isOutlined && 'outline outline-2'} 

--- a/src/components/Introduction/Introduction.spec.tsx
+++ b/src/components/Introduction/Introduction.spec.tsx
@@ -1,0 +1,42 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+
+import Introduction from '.'
+
+describe('<Introduction />', () => {
+  beforeEach(() => {
+    render(<Introduction />)
+  })
+
+  it('should render texts correctly', () => {
+    const title = 'Virtual healthcare for you'
+    const subTitle =
+      'Trafalgar provides progressive, and affordable healthcare, accessible on mobile and online for everyone'
+
+    expect(screen.getByText(title)).toBeInTheDocument()
+    expect(screen.getByText(subTitle)).toBeInTheDocument()
+  })
+
+  it('should render button correctly', () => {
+    const button = 'Consult today'
+
+    expect(screen.getByText(button)).toBeInTheDocument()
+  })
+
+  it('should render image correctly', () => {
+    const altImage = 'Decorative medical design'
+
+    expect(screen.getByAltText(altImage)).toBeInTheDocument()
+  })
+
+  it('should hidden image in mobile', () => {
+    const altImage = 'Decorative medical design'
+
+    window.innerWidth = 500
+
+    fireEvent(window, new Event('resize'))
+
+    waitFor(() => {
+      expect(screen.getByAltText(altImage)).not.toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/Introduction/index.tsx
+++ b/src/components/Introduction/index.tsx
@@ -13,10 +13,11 @@ const Introduction = () => {
           on mobile and online for everyone
         </p>
         <Button
-          content='Button'
-          textColor='text-blue-500'
-          style='outlined'
+          content='Consult today'
+          textColor='text-white'
           padding='px-9'
+          bgColor='bg-blue-500'
+          style='filled'
         />
       </div>
       <Image

--- a/src/components/Introduction/index.tsx
+++ b/src/components/Introduction/index.tsx
@@ -5,10 +5,10 @@ import Button from '../Button'
 
 const Introduction = () => {
   return (
-    <section className='px-48 flex justify-center items-center gap-28'>
+    <section className='max-md:px-4 px-48 flex justify-center items-center gap-28'>
       <div>
-        <Title content='Virtual healthcare for you' width='w-[427px]' />
-        <p className='text-gray-500 text-xl mt-6 mb-11 w-[410px]'>
+        <Title content='Virtual healthcare for you' width='max-w-[427px]' />
+        <p className='text-gray-500 text-xl mt-6 mb-11 max-w-[410px]'>
           Trafalgar provides progressive, and affordable healthcare, accessible
           on mobile and online for everyone
         </p>
@@ -20,12 +20,14 @@ const Introduction = () => {
           style='filled'
         />
       </div>
-      <Image
-        src='https://media.discordapp.net/attachments/778024116140769331/1137638119047446629/trafalgar-header_illustration_1.png'
-        alt='decorative image'
-        width={700}
-        height={600}
-      />
+      <div className='hidden lg:block'>
+        <Image
+          src='https://media.discordapp.net/attachments/778024116140769331/1137638119047446629/trafalgar-header_illustration_1.png'
+          alt='decorative image'
+          width={700}
+          height={600}
+        />
+      </div>
     </section>
   )
 }

--- a/src/components/Introduction/index.tsx
+++ b/src/components/Introduction/index.tsx
@@ -1,0 +1,25 @@
+import Image from 'next/image'
+
+import Title from '../Title'
+
+const Introduction = () => {
+  return (
+    <section className='px-48 flex justify-center items-center gap-28'>
+      <div>
+        <Title content='Virtual healthcare for you' width='w-[427px]' />
+        <p className='text-gray-500 text-xl mt-6 w-[410px]'>
+          Trafalgar provides progressive, and affordable healthcare, accessible
+          on mobile and online for everyone
+        </p>
+      </div>
+      <Image
+        src='https://media.discordapp.net/attachments/778024116140769331/1137638119047446629/trafalgar-header_illustration_1.png'
+        alt='decorative image'
+        width={700}
+        height={600}
+      />
+    </section>
+  )
+}
+
+export default Introduction

--- a/src/components/Introduction/index.tsx
+++ b/src/components/Introduction/index.tsx
@@ -23,7 +23,7 @@ const Introduction = () => {
       <div className='hidden lg:block'>
         <Image
           src='https://media.discordapp.net/attachments/778024116140769331/1137638119047446629/trafalgar-header_illustration_1.png'
-          alt='decorative image'
+          alt='Decorative medical design'
           width={700}
           height={600}
         />

--- a/src/components/Introduction/index.tsx
+++ b/src/components/Introduction/index.tsx
@@ -12,7 +12,12 @@ const Introduction = () => {
           Trafalgar provides progressive, and affordable healthcare, accessible
           on mobile and online for everyone
         </p>
-        <Button content='Consult today' color='bg-blue-500' />
+        <Button
+          content='Button'
+          textColor='text-blue-500'
+          style='outlined'
+          padding='px-9'
+        />
       </div>
       <Image
         src='https://media.discordapp.net/attachments/778024116140769331/1137638119047446629/trafalgar-header_illustration_1.png'

--- a/src/components/Introduction/index.tsx
+++ b/src/components/Introduction/index.tsx
@@ -1,16 +1,18 @@
 import Image from 'next/image'
 
 import Title from '../Title'
+import Button from '../Button'
 
 const Introduction = () => {
   return (
     <section className='px-48 flex justify-center items-center gap-28'>
       <div>
         <Title content='Virtual healthcare for you' width='w-[427px]' />
-        <p className='text-gray-500 text-xl mt-6 w-[410px]'>
+        <p className='text-gray-500 text-xl mt-6 mb-11 w-[410px]'>
           Trafalgar provides progressive, and affordable healthcare, accessible
           on mobile and online for everyone
         </p>
+        <Button content='Consult today' color='bg-blue-500' />
       </div>
       <Image
         src='https://media.discordapp.net/attachments/778024116140769331/1137638119047446629/trafalgar-header_illustration_1.png'

--- a/src/components/Title/Title.spec.tsx
+++ b/src/components/Title/Title.spec.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react'
+
+import Title from '.'
+
+describe('<Title />', () => {
+  it('should render title correctly', () => {
+    const title = 'Shiryu amigo'
+
+    render(<Title content={title} />)
+
+    expect(screen.getByText(title)).toBeInTheDocument()
+  })
+})

--- a/src/components/Title/index.tsx
+++ b/src/components/Title/index.tsx
@@ -4,7 +4,7 @@ type TitleProps = {
 }
 
 const Title = ({ content, width }: TitleProps) => {
-  return <h1 className={`text-5xl font-bold ${width}`}>{content}</h1>
+  return <h1 className={`text-5xl font-bold break-all ${width}`}>{content}</h1>
 }
 
 export default Title

--- a/src/components/Title/index.tsx
+++ b/src/components/Title/index.tsx
@@ -1,0 +1,10 @@
+type TitleProps = {
+  content: string
+  width?: string
+}
+
+const Title = ({ content, width }: TitleProps) => {
+  return <h1 className={`text-5xl font-bold ${width}`}>{content}</h1>
+}
+
+export default Title


### PR DESCRIPTION
## Infos

- Create [section introduction](https://www.figma.com/file/EWmzcVkd7qbP5Nf7iMvuqP/Trafalgar-Landing-Page?type=design&node-id=63-2662&mode=design&t=wOo0hIUaWuN9dlSO-4)
- Create global button component 
- Configure images domain to use discord path

## Evidences 
- Desktop
![image](https://github.com/gabrielduete/virtual-healthcare/assets/59345698/6652dbdc-21aa-4447-a6d8-97cb7e1de077)
- Mobile
![image](https://github.com/gabrielduete/virtual-healthcare/assets/59345698/3b208744-8e5a-4947-b189-cc742b3af878)


### Button
- Filled
![image](https://github.com/gabrielduete/virtual-healthcare/assets/59345698/df5fa215-58b7-4096-bbaa-7ed7bd4c2794)

- Outlined 
![image](https://github.com/gabrielduete/virtual-healthcare/assets/59345698/f29f957c-316b-4b44-9e4f-c07ac303e9da)
